### PR TITLE
Switch from fixed circle radius to fixed user spacing

### DIFF
--- a/packages/aardvark-react/src/aardvark_chamber.tsx
+++ b/packages/aardvark-react/src/aardvark_chamber.tsx
@@ -160,7 +160,8 @@ export class AvDefaultChamber extends React.Component< AvDefaultChamberProps, Av
 			let rotationIndex = ( n - localUserIndex + members.length ) % members.length;
 			let yRotRadians = rotationIndex * 360 / members.length;
 
-			const circleRadius = 0.5;
+			const userSeparation = 1;  //meters
+			let circleRadius = members.length == 1 ? 0 : userSeparation / (2 * Math.sin(Math.PI / members.length));
 
 			stateMembers.push(
 				{


### PR DESCRIPTION
This will change the current layout of members in a chamber to be a fixed 1 meter apart from the people closest to them in the circle rather than having a fixed circle of diameter 1 meter.  This means the circle expands slightly as participants are added.  This starts to break down visually once your group is large enough, but at a certain point you probably want something other than a circle.