### PR TITLE
initial singleton gadget implementation

### DIFF
--- a/packages/aardvark-shared/src/aardvark_protocol.ts
+++ b/packages/aardvark-shared/src/aardvark_protocol.ts
@@ -750,6 +750,7 @@ export interface AardvarkManifestExtension
 	browserWidth: number;
 	browserHeight: number;
 	startAutomatically: boolean;
+	restrictToSingleInstance: boolean;
 }
 
 export interface AardvarkManifest extends WebAppManifest
@@ -757,8 +758,6 @@ export interface AardvarkManifest extends WebAppManifest
 	xr_type: string;
 	aardvark: AardvarkManifestExtension;
 }
-
-
 
 export enum EAction
 {

--- a/src/aardvark/aardvark_gadget_manifest.cpp
+++ b/src/aardvark/aardvark_gadget_manifest.cpp
@@ -6,6 +6,7 @@ void to_json( nlohmann::json& j, const CAardvarkManifestExtension& gm )
 		{ "permissions", gm.m_permissions },
 		{ "browserWidth", gm.m_width },
 		{ "browserHeight", gm.m_height },
+		{ "restrictToSingleInstance", gm.m_restrictToSingleInstance},
 	};
 }
 
@@ -21,6 +22,16 @@ void from_json( const nlohmann::json& j, CAardvarkManifestExtension& gm )
 	{
 		(void)e;
 		gm.m_width = gm.m_height = 16;
+	}
+
+	try
+	{
+		j.at( "restrictToSingleInstance" ).get_to( gm.m_restrictToSingleInstance );
+	}
+	catch ( nlohmann::json::exception& e )
+	{
+		(void)e;
+		gm.m_restrictToSingleInstance = false;
 	}
 }
 

--- a/src/avrenderer/av_cef_app.cpp
+++ b/src/avrenderer/av_cef_app.cpp
@@ -155,7 +155,6 @@ void CAardvarkCefApp::OnContextInitialized()
 	startGadget( params );
 }
 
-
 void CAardvarkCefApp::startGadget( const aardvark::GadgetParams_t& params )
 {
 	CEF_REQUIRE_UI_THREAD();
@@ -164,6 +163,13 @@ void CAardvarkCefApp::startGadget( const aardvark::GadgetParams_t& params )
 	CefRefPtr<CAardvarkCefHandler> handler( new CAardvarkCefHandler( this, params ) );
 	m_browsers.push_back( handler );
 	handler->start();
+}
+
+bool CAardvarkCefApp::IsInstanceOfGadgetRunning( const aardvark::GadgetParams_t& params )
+{
+	return std::any_of(m_browsers.begin(), m_browsers.end(), [&params](const auto& handler) -> bool {
+		return handler->IsInstanceOfGadget(params);
+	});
 }
 
 

--- a/src/avrenderer/av_cef_app.h
+++ b/src/avrenderer/av_cef_app.h
@@ -36,6 +36,8 @@ public:
 
 	void startGadget( const aardvark::GadgetParams_t& params );
 
+	bool IsInstanceOfGadgetRunning( const aardvark::GadgetParams_t& params );
+
 	virtual void quitRequested() override;
 	virtual void browserClosed( CAardvarkCefHandler *handler ) override;
 	virtual bool createTextureForBrowser( void **sharedHandle,

--- a/src/avrenderer/av_cef_handler.cpp
+++ b/src/avrenderer/av_cef_handler.cpp
@@ -70,6 +70,13 @@ void CAardvarkCefHandler::onGadgetManifestReceived( bool success, const std::vec
 		return;
 	}
 
+	if (m_gadgetManifest.m_aardvark.m_restrictToSingleInstance 
+	    && CAardvarkCefApp::instance()->IsInstanceOfGadgetRunning( m_params ) )
+	{
+		LOG( INFO ) << "duplicate creation of singleton gadget " << this->m_params.uri << ".";
+		return;
+	}
+
 	m_gadgetManifestString = std::string( manifestData.begin(), manifestData.end() );
 
 	// Specify CEF browser settings here.

--- a/src/avrenderer/av_cef_handler.h
+++ b/src/avrenderer/av_cef_handler.h
@@ -111,7 +111,7 @@ public:
 		TerminationStatus status ) override;
 
 	bool IsClosing() const { return m_isClosing; }
-
+	bool IsInstanceOfGadget( const aardvark::GadgetParams_t& params ) const { return m_params.uri == params.uri; };
 	void triggerClose( bool forceClose );
 
 	// Called after creation to kick off the gadget
@@ -122,6 +122,7 @@ public:
 
 	// Called when a window info changes for a subscribed window
 	void windowUpdate( CefRefPtr<CefListValue> windowInfo );
+
 private:
 	// Platform-specific implementation.
 	void PlatformTitleChange(CefRefPtr<CefBrowser> browser,

--- a/src/public/aardvark/aardvark_gadget_manifest.h
+++ b/src/public/aardvark/aardvark_gadget_manifest.h
@@ -8,6 +8,7 @@ class CAardvarkManifestExtension
 public:
 	std::unordered_set<std::string> m_permissions;
 	uint32_t m_width = 16, m_height = 16;
+	bool m_restrictToSingleInstance = false;
 };
 
 void to_json( nlohmann::json& j, const CAardvarkManifestExtension& gm );

--- a/websrc/__tests__/endpoint-test.ts
+++ b/websrc/__tests__/endpoint-test.ts
@@ -79,7 +79,8 @@ beforeEach( async() =>
 									permissions: [],
 									browserWidth: 16,
 									browserHeight: 16,
-									startAutomatically: false,	
+									startAutomatically: false,
+									restrictToSingleInstance: false,
 								}
 							}
 						}


### PR DESCRIPTION
I'm not sure with CEF behavior if returning after the get gadget manifest will properly clean up the browser or if more must be done.