### PR TITLE
Use cog for menu if controller type is unknown

### DIFF
--- a/websrc/default_hands/src/default_hands_main.tsx
+++ b/websrc/default_hands/src/default_hands_main.tsx
@@ -1059,16 +1059,7 @@ class DefaultHands extends React.Component< {}, DefaultHandsState >
 
 		this.controllerVolumes = volumeDictionary.has(inputProcessor.currentInteractionProfile) ? volumeDictionary.get(inputProcessor.currentInteractionProfile) : null;
 
-		if ( this.controllerVolumes )
-		{
-			console.log("currentInteraction profile is " + inputProcessor.currentInteractionProfile + " and is in the volume dictionary");
-		}
-		else
-		{
-			console.log("currentInteraction profile is " + inputProcessor.currentInteractionProfile + " and isn't in the volume dictionary");
-			this.controllerVolumes = volumeDictionary.get( "default" );
-		}
-		
+		console.log("currentInteraction profile is " + inputProcessor.currentInteractionProfile + ` and ${this.controllerVolumes ? 'is' : 'is not'} in the volume dictionary`)
 
 		return (
 			<>


### PR DESCRIPTION
This PR switches back to using the cog button to open the menu if the controller type is unknown in the gesture volume dictionary.

Before, it would use the volumes for an index controller if the controller volumes could not be found, which could set the positions of the volumes incorrectly making it very difficult to open the menu.